### PR TITLE
fix errors in README

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -181,7 +181,7 @@ OK
 | EXSETVER      | EXSETVER \<key\> \<version\>                                                                                                                                                     | 直接对一个 key 设置 version，类似于 EXSET ABS                                                                     |
 | EXINCRBY      | EXINCRBY \<key\> \<num\> [EX time][px time] [EXAT time][exat time] [PXAT time][nx &#124; xx] [VER version &#124; ABS version][min minval] [MAX maxval][nonegative] [WITHVERSION] | 对 Key 做自增自减操作，num 的范围为 long。                                                                        |
 | EXINCRBYFLOAT | EXINCRBYFLOAT \<key\> \<num\> [EX time][px time] [EXAT time][exat time] [PXAT time][nx &#124; xx] [VER version &#124; ABS version][min minval] [MAX maxval]                      | 对 Key 做自增自减操作，num 的范围为 double。                                                                      |
-| EXCAS         | EXCAS \<key\> \<newvalue\> \<version\>                                                                                                                                           | 指定 version 将 value 更新，当引擎中的 version 和指定的相同时才更新成功，不成功会返回旧的 value 和 version。      |
+| EXCAS         | EXCAS \<key\> \<newvalue\> \<version\> [EX time] [PX time] [EXAT time] [PXAT time] [KEEPTTL]                                                                                     | 指定 version 将 value 更新，当引擎中的 version 和指定的相同时才更新成功，不成功会返回旧的 value 和 version。      |
 | EXCAD         | EXCAD \<key\> \<version\>                                                                                                                                                        | 当指定 version 和引擎中 version 相等时候删除 Key，否则失败。                                                      |
 | EXAPPEND      | EXAPPEND \<key\> \<value\> [NX\|XX][ver version \| abs version]                                                                                                                  | 对 key 做字符串 append 操作                                                                                       |
 | EXPREPEND     | EXPREPEND \<key\> \<value\> [NX\|XX][ver version \| abs version]                                                                                                                 | 对 key 做字符串 prepend 操作                                                                                      |
@@ -420,7 +420,7 @@ OK
 ## EXCAS
 
 语法及复杂度：
-> EXCAS <key> <newvalue> <version>  
+> EXCAS <key> <newvalue> <version> [EX time] [PX time] [EXAT time] [PXAT time] [KEEPTTL]  
 > 时间复杂度：O(1)
 
 命令描述：

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ OK
 | EXSETVER      | EXSETVER \<key\> \<version\>                                                                                                                                                     | Set the version directly to a key, which is equivalent to EXSET ABS                                                                 |
 | EXINCRBY      | EXINCRBY \<key\> \<num\> [EX time][px time] [EXAT time][exat time] [PXAT time][nx &#124; xx] [VER version &#124; ABS version][min minval] [MAX maxval][nonegative] [WITHVERSION] | Auto-increment or decrement the Key                             |
 | EXINCRBYFLOAT | EXINCRBYFLOAT \<key\> \<num\> [EX time][px time] [EXAT time][exat time] [PXAT time][nx &#124; xx] [VER version &#124; ABS version][min minval] [MAX maxval]                      | Do the increment and decrement operations on Key, and the range of num is double                                   |
-| EXCAS         | EXCAS \<key\> \<newvalue\> \<version\>                                                                                                                                           | Specify version to update the value. The update is successful when the version in the engine is the same as the specified one. If it fails, the old value and version will be returned      |
+| EXCAS         | EXCAS \<key\> \<newvalue\> \<version\> [EX time] [PX time] [EXAT time] [PXAT time] [KEEPTTL]                                                                                     | Specify version to update the value. The update is successful when the version in the engine is the same as the specified one. If it fails, the old value and version will be returned      |
 | EXCAD         | EXCAD \<key\> \<version\>                                                                                                                                                        | Delete the Key when the specified version is equal to the version in the engine, otherwise it will fail                                |
 | EXAPPEND      | EXAPPEND \<key\> \<value\> [NX\|XX][ver version \| abs version]                                                                                                                  | Append string to key|
 | EXPREPEND     | EXPREPEND \<key\> \<value\> [NX\|XX][ver version \| abs version]                                                                                                                 | Perform string prepend operation on key|
@@ -411,7 +411,7 @@ OK
 ## EXCAS
 
 Grammar and complexity：
-> EXCAS <key> <newvalue> <version>  
+> EXCAS <key> <newvalue> <version> [EX time] [PX time] [EXAT time] [PXAT time] [KEEPTTL]  
 > time complexity：O(1)
 
 Command description：


### PR DESCRIPTION
In the [source code](https://github.com/alibaba/TairString/blob/aef15edc001f4c0f43de085144fa252d8125a98e/src/tairstring.c#L758), the format of EXCAS command is "EXCAS \<key\> \<new_value\> \<version\> [EX/EXAT/PX/PXAT time] [KEEPTTL]". But in README, it is "EXCAS \<key\> \<newvalue\> \<version\>".